### PR TITLE
Feature/update connect client

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "php": ">=7.0",
         "ext-openssl": "*",
         "objective-php/application": "^2.0",
-        "fei/connect-client": "~3.0.0"
+        "fei/connect-client": "~3.1.0"
     },
     "require-dev": {
         "codeception/codeception": "^2.4",

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "repositories" : [
         {
             "type" : "git",
-            "url": "git@github.com:flash-global/connect-client.git"
+            "url": "https://github.com/flash-global/connect-client.git"
         }
     ],
     "config": {

--- a/composer.json
+++ b/composer.json
@@ -15,12 +15,6 @@
             "Fei\\Service\\Connect\\Package\\": "src/"
         }
     },
-    "repositories" : [
-        {
-            "type" : "git",
-            "url": "https://github.com/flash-global/connect-client.git"
-        }
-    ],
     "config": {
         "platform": {
             "php": "7.0.27"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "26ddf3d359b803a921d3306467d7abef",
+    "content-hash": "a508a87597a64c9d1794fb55378150e8",
     "packages": [
         {
             "name": "container-interop/container-interop",
@@ -337,7 +337,7 @@
             "version": "v3.1.0",
             "source": {
                 "type": "git",
-                "url": "git@github.com:flash-global/connect-client.git",
+                "url": "https://github.com/flash-global/connect-client.git",
                 "reference": "593d2db0a55c271ec4827e001cdb0e24d1269751"
             },
             "require": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5ac665fb48d19b159de9dd1f6c29246d",
+    "content-hash": "26ddf3d359b803a921d3306467d7abef",
     "packages": [
         {
             "name": "container-interop/container-interop",
@@ -285,16 +285,16 @@
         },
         {
             "name": "fei/api-client",
-            "version": "v1.2.7",
+            "version": "v1.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/flash-global/api-client.git",
-                "reference": "0e0911feccf62d6c1c00c51d3a14cc989151d252"
+                "reference": "f925992cbda504a466a8cb36f0e7f509a4a5b53f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/flash-global/api-client/zipball/0e0911feccf62d6c1c00c51d3a14cc989151d252",
-                "reference": "0e0911feccf62d6c1c00c51d3a14cc989151d252",
+                "url": "https://api.github.com/repos/flash-global/api-client/zipball/f925992cbda504a466a8cb36f0e7f509a4a5b53f",
+                "reference": "f925992cbda504a466a8cb36f0e7f509a4a5b53f",
                 "shasum": ""
             },
             "require": {
@@ -305,6 +305,8 @@
             "require-dev": {
                 "codeception/aspect-mock": "*",
                 "codeception/codeception": "^2.2",
+                "jakub-onderka/php-parallel-lint": "^1.0",
+                "phpro/grumphp": "^0.14.2",
                 "squizlabs/php_codesniffer": "3.*"
             },
             "bin": [
@@ -328,24 +330,18 @@
                 }
             ],
             "description": "Client side API helpers",
-            "time": "2018-03-15T16:08:51+00:00"
+            "time": "2018-09-20T15:13:53+00:00"
         },
         {
             "name": "fei/connect-client",
-            "version": "v3.0.2",
+            "version": "v3.1.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/flash-global/connect-client.git",
-                "reference": "a00e14d2f93cbb1fafe56f59fed5a07c662a5d26"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/flash-global/connect-client/zipball/a00e14d2f93cbb1fafe56f59fed5a07c662a5d26",
-                "reference": "a00e14d2f93cbb1fafe56f59fed5a07c662a5d26",
-                "shasum": ""
+                "url": "git@github.com:flash-global/connect-client.git",
+                "reference": "593d2db0a55c271ec4827e001cdb0e24d1269751"
             },
             "require": {
-                "fei/api-client": "~1.2.0",
+                "fei/api-client": "^1.3",
                 "fei/connect-common": "^3.0.0",
                 "lightsaml/lightsaml": "^1.2",
                 "nikic/fast-route": "^1.0",
@@ -366,7 +362,6 @@
                     "Fei\\Service\\Connect\\Client\\": "src"
                 }
             },
-            "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "GPL-3.0"
             ],
@@ -378,7 +373,7 @@
                 }
             ],
             "description": "Yoctu Connect Client - Service Provider",
-            "time": "2018-09-14T13:17:51+00:00"
+            "time": "2018-09-27T08:36:21+00:00"
         },
         {
             "name": "fei/connect-common",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a508a87597a64c9d1794fb55378150e8",
+    "content-hash": "0e7b5575ca2c58a9e75c15302260fb02",
     "packages": [
         {
             "name": "container-interop/container-interop",


### PR DESCRIPTION
- update connect-client 3.1.0
- update ssh link with https link for connect-client (Travis Ci can't cloning public repository with ssh method. https link is needed)